### PR TITLE
disable install, as otherwise 'minizip' got into xcarchive Products (…

### DIFF
--- a/minizip.xcodeproj/project.pbxproj
+++ b/minizip.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -356,6 +357,7 @@
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
…/usr/local/lib) which then confused export archive and it spawned 'useful' error 'exportOptionsPlist error for key 'method': expected one of {}, but found ad-hoc'